### PR TITLE
fix: filename_expansion()

### DIFF
--- a/src/expansion_filename.c
+++ b/src/expansion_filename.c
@@ -101,12 +101,16 @@ static int	check_valid_star(char *word)
 t_exe_lst	*filename_expansion(char *word)
 {
 	const size_t	wordlen = ft_strlen(word);
-	const int		only_dir = word[wordlen - 1] == '/';
+	int				only_dir;
 	t_exe_lst		*exes;
 	DIR				*dir;
 	struct dirent	*entry;
 
 	exes = new_exe_lst();
+	if (wordlen == 0)
+		exe_lst_new_back(exes, ft_strdup(word));
+	only_dir = word[wordlen - 1] == '/';
+	return (exes);
 	if (!check_valid_star(word))
 	{
 		exe_lst_new_back(exes, ft_strdup(word));

--- a/src/expansion_filename.c
+++ b/src/expansion_filename.c
@@ -107,15 +107,12 @@ t_exe_lst	*filename_expansion(char *word)
 	struct dirent	*entry;
 
 	exes = new_exe_lst();
-	if (wordlen == 0)
-		exe_lst_new_back(exes, ft_strdup(word));
-	only_dir = word[wordlen - 1] == '/';
-	return (exes);
-	if (!check_valid_star(word))
+	if (wordlen == 0 || !check_valid_star(word))
 	{
 		exe_lst_new_back(exes, ft_strdup(word));
 		return (exes);
 	}
+	only_dir = word[wordlen - 1] == '/';
 	if (only_dir)
 		word[wordlen - 1] = '\0';
 	dir = null_guard(opendir("."), PROGRAM_NAME, "filename_expansion().");

--- a/src/expansion_filename.c
+++ b/src/expansion_filename.c
@@ -46,18 +46,25 @@ static int	is_matched(const char *pattern, const char *string,
 	return (*pattern == *string);
 }
 
+static void	add_filename(t_exe_lst *exes, char *filename, int only_dir)
+{
+	char	*tmp;
+
+	tmp = ft_strjoin("\a", filename);
+	if (only_dir)
+		exe_lst_new_back(exes, ft_strjoin(tmp, "/\a"));
+	else
+		exe_lst_new_back(exes, ft_strjoin(tmp, "\a"));
+	free(tmp);
+}
+
 static void	inner_while(char *word, int only_dir,
 		t_exe_lst *exes, struct dirent *entry)
 {
 	if (!((word[0] != '.' && entry->d_name[0] == '.')
 			|| (only_dir && entry->d_type != DT_DIR))
 		&& is_matched(word, entry->d_name, 0, 0))
-	{
-		if (only_dir)
-			exe_lst_new_back(exes, ft_strjoin(entry->d_name, "/"));
-		else
-			exe_lst_new_back(exes, ft_strdup(entry->d_name));
-	}
+		add_filename(exes, entry->d_name, only_dir);
 }
 
 t_exe_lst	*filename_expansion(char *word)
@@ -80,11 +87,6 @@ t_exe_lst	*filename_expansion(char *word)
 	}
 	closedir(dir);
 	if (exes->size == 0)
-	{
-		if (only_dir)
-			exe_lst_new_back(exes, ft_strjoin(word, "/"));
-		else
-			exe_lst_new_back(exes, ft_strdup(word));
-	}
+		add_filename(exes, word, only_dir);
 	return (exes);
 }

--- a/src/expansion_filename.c
+++ b/src/expansion_filename.c
@@ -51,20 +51,23 @@ static void	add_filename(t_exe_lst *exes, char *filename,
 {
 	char	*tmp;
 
-	if (flag_no_match)
+	if (flag_no_match == -1)
+	{
+		tmp = ft_strjoin("\a", filename);
+		if (only_dir)
+			exe_lst_new_back(exes, ft_strjoin(tmp, "/\a"));
+		else
+			exe_lst_new_back(exes, ft_strjoin(tmp, "\a"));
+		free(tmp);
+		return ;
+	}
+	if (flag_no_match == 0)
 	{
 		if (only_dir)
 			exe_lst_new_back(exes, ft_strjoin(filename, "/"));
 		else
 			exe_lst_new_back(exes, ft_strdup(filename));
-		return ;
 	}
-	tmp = ft_strjoin("\a", filename);
-	if (only_dir)
-		exe_lst_new_back(exes, ft_strjoin(tmp, "/\a"));
-	else
-		exe_lst_new_back(exes, ft_strjoin(tmp, "\a"));
-	free(tmp);
 }
 
 static void	inner_while(char *word, int only_dir,
@@ -73,7 +76,7 @@ static void	inner_while(char *word, int only_dir,
 	if (!((word[0] != '.' && entry->d_name[0] == '.')
 			|| (only_dir && entry->d_type != DT_DIR))
 		&& is_matched(word, entry->d_name, 0, 0))
-		add_filename(exes, entry->d_name, only_dir, 0);
+		add_filename(exes, entry->d_name, only_dir, -1);
 }
 
 static int	check_valid_star(char *word)
@@ -123,7 +126,6 @@ t_exe_lst	*filename_expansion(char *word)
 		entry = readdir(dir);
 	}
 	closedir(dir);
-	if (exes->size == 0)
-		add_filename(exes, word, only_dir, 1);
+	add_filename(exes, word, only_dir, exes->size);
 	return (exes);
 }

--- a/src/expansion_quote_removal.c
+++ b/src/expansion_quote_removal.c
@@ -35,7 +35,7 @@ char	*quote_removal(char	*word)
 	init_vector(&vector);
 	while (word[i] != '\0')
 	{
-		if (word[i] == '\"' || word[i] == '\'')
+		if (word[i] == '\"' || word[i] == '\'' || word[i] == '\a')
 			handling_quote(word, &i, &vector);
 		else
 			push_back(&vector, word[i++]);


### PR DESCRIPTION
filename expansion으로 확장된 것들은 quote removal 하지 않도록 하였습니다.
filename expansion에 빈 문자열이 들어오는 경우 segfault가 나는 것도 해결했습니다.