### PR TITLE
fix: echo hi <

### DIFF
--- a/src/parse_simple_command.c
+++ b/src/parse_simple_command.c
@@ -46,7 +46,7 @@ static	t_tree	*set_tree_to_smpl_cmd_continue(t_list **tokens, t_tree *tree)
 	tree->category = TR_SMPL_CMD_CONTINUE;
 	tree->right = parse_simple_command(tokens);
 	if (tree->right == NULL)
-		panic("parse_simple_command()");
+		return (destroy_tree(tree));
 	return (tree);
 }
 


### PR DESCRIPTION
- `echo hi <`
- `cat <| ls`
입력되면 쉘 종료되는 에러 해결했습니다.