### PR TITLE
fix: parse pipeline (ls)

### DIFF
--- a/src/parse_pipeline.c
+++ b/src/parse_pipeline.c
@@ -32,6 +32,8 @@ static int	parse_paren(t_list **tokens, t_tree *tree, t_token *token)
 	if (token->category != T_R_PAREN)
 		panic("parse_paren()");
 	*tokens = (*tokens)->next;
+	if (*tokens == NULL)
+		return (0);
 	token = (*tokens)->content;
 	if (token->category == T_PIPE)
 	{
@@ -54,6 +56,8 @@ static t_tree	*parse_pipe_continue(t_tree *tree, t_list **tokens)
 
 	tree->category = TR_PIPE_CONTINUE;
 	*tokens = (*tokens)->next;
+	if (*tokens == NULL)
+		return (print_parse_error(*tokens, tree));
 	token = (*tokens)->content;
 	if (token->category == T_L_PAREN)
 		return (print_parse_error(*tokens, tree));


### PR DESCRIPTION
- `(ls)`

괄호 파싱 관련해서 잘 못 수정했던 부분 고쳤습니다.