### PR TITLE
Leak/heredoc quote

### DIFF
--- a/src/here_document.c
+++ b/src/here_document.c
@@ -42,28 +42,31 @@ static void	inner_while(int heredoc_fd, char **line,
 
 static int	here_doc_action(char *filename, char *limiter, t_dict *env_dict)
 {
-	size_t	limiter_len;
-	char	*line;
-	int		heredoc_fd;
-	char	*limiter_without_quote;
-
-	limiter_without_quote = quote_removal(limiter);
-	limiter_len = ft_strlen(limiter_without_quote);
-	heredoc_fd = func_guard(open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644),
+	char			*line;
+	const char		*limiter_without_quote = quote_removal(limiter);
+	const size_t	limiter_len = ft_strlen(limiter_without_quote);
+	const int		heredoc_fd = func_guard(
+			open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644),
 			PROGRAM_NAME, "here_doc_action().");
+
 	line = readline("> ");
 	if (line == NULL)
+	{
+		free((void *)limiter_without_quote);
 		return (close(heredoc_fd));
+	}
 	while (!(ft_strncmp(line, limiter_without_quote, limiter_len + 1) == 0))
 	{
 		inner_while(heredoc_fd, &line, env_dict, !is_contain_quote(limiter));
 		if (line == NULL)
+		{
+			free((void *)limiter_without_quote);
 			return (close(heredoc_fd));
+		}
 	}
 	free(line);
-	free(limiter_without_quote);
-	close(heredoc_fd);
-	return (0);
+	free((void *)limiter_without_quote);
+	return (close(heredoc_fd));
 }
 
 static void	switch_here_doc_norm(t_dict *env_dict, int fd)


### PR DESCRIPTION
here document limiter에서 따옴표를 제거하는 중에 생기는 누수를 해결했습니다.